### PR TITLE
feat: add html for editing references

### DIFF
--- a/src/templates/edit_reference.html
+++ b/src/templates/edit_reference.html
@@ -1,0 +1,92 @@
+{% extends "layout.html" %}
+
+{% block title %}Edit reference: {{ reference.name }}{% endblock %}
+
+{% block head %} 
+<script src="../static/scripts/new_reference.js" defer></script> 
+{% endblock %}
+
+{% block body %}
+
+<h2>Edit reference: {{ reference.name }}</h2>
+
+<form action="/edit_reference/{{ reference.id }}" method="post">
+    {% with messages = get_flashed_messages() %}
+    {% if messages %}
+        <ul>
+            {% for message in messages %}
+            <li>{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+    {% endwith %}
+
+    <div>
+        <label for="type">Reference type:</label>
+        <select name="type" id="type" required>
+            {% for type in all_refs %}
+                {% if type == reference.type %}
+                <option value="{{ type }}" selected>{{ type }}</option>
+                {% else %}
+                <option value="{{ type }}">{{ type }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+    </div>
+
+    <div>
+        <label for="name">Reference name:</label>
+        <input type="text" name="name" id="name" value="{{ reference.name }}" maxlength="100" required>
+    </div>
+    <br>
+
+    <div id="required-fields">
+        Required Fields:<br>
+        {% for field_name in required %}
+            {% set field_obj = reference.fields | selectattr("type", "equalto", field_name) | first %}
+            <label for="{{ field_name }}">{{ field_name }}: </label>
+            <input type="text" name="{{ field_name }}" id="{{ field_name }}" 
+                   value="{{ field_obj.value if field_obj else '' }}" required maxlength="500"> <br>
+        {% endfor %}
+        <br>
+    </div>
+
+    <div id="optional-fields">
+        Optional Fields:<br>
+        {% set optional_fields_present = false %}
+        {% for field_name in optional %}
+            {% set field_obj = reference.fields | selectattr("type", "equalto", field_name) | first %}
+            {% if field_obj %}
+                {% set optional_fields_present = true %}
+                <div>
+                    <label for="{{ field_name }}">{{ field_name }}: </label>
+                    <input type="text" name="{{ field_name }}" id="{{ field_name }}" value="{{ field_obj.value }}" maxlength="500">
+                </div>
+            {% endif %}
+        {% endfor %}
+        {% if not optional_fields_present %}
+        <p id="no-optionals">No optional fields added.</p>
+        {% endif %}
+    </div>
+
+    <input type="submit" value="Save changes">
+</form>
+
+<hr>
+
+<div id="optional-fields-adder">
+    <label for="optional-select" id="optional-label">Optional fields:</label>
+    <select name="optional-select" id="optional-select">
+        {% for field_name in optional %}
+            {% set exists = reference.fields | selectattr("type", "equalto", field_name) | list %}
+            {% if not exists %}
+                <option value="{{ field_name }}">{{ field_name }}</option>
+            {% endif %}
+        {% endfor %}
+    </select>
+    <button type="button" id="optional-button">Add optional field</button>
+</div>
+
+<hr>
+
+{% endblock %}


### PR DESCRIPTION
### Description

Add HTML form to edit references

### Motivation

This change enhances the functionality of the application by allowing user to edit mistakes and add more information for existing reference.

### Related Issues

closes #23

### Architecture Changes

HTML template only

### Testing

No changes

### Documentation

No changes