### PR TITLE
test: convert reference_types_test.py from pytest to unittest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ report.html
 *.log
 *.png
 .coverage
+.DS_Store

--- a/src/tests/services_test/reference_types_test.py
+++ b/src/tests/services_test/reference_types_test.py
@@ -1,67 +1,67 @@
-import pytest
+import unittest
 
 from src.scripts.bibtex_types import types
 from src.services.reference_types import get_reference_fields, get_reference_types
 
 
-def test_get_reference_types_matches_keys():
-    assert get_reference_types() == set(types.keys())
+class TestReferenceTypes(unittest.TestCase):
+    def test_get_reference_types_matches_keys(self):
+        self.assertEqual(get_reference_types(), set(types.keys()))
 
+    def test_get_reference_fields_valid(self):
+        for ref_type in types:
+            required, optional = get_reference_fields(ref_type)
+            self.assertIsInstance(required, list)
+            self.assertIsInstance(optional, list)
+            for f in required:
+                self.assertIsInstance(f, str)
+            for f in optional:
+                self.assertIsInstance(f, str)
 
-def test_get_reference_fields_valid():
-    for ref_type in types:
-        required, optional = get_reference_fields(ref_type)
-        assert isinstance(required, list)
-        assert isinstance(optional, list)
-        assert all(isinstance(f, str) for f in required)
-        assert all(isinstance(f, str) for f in optional)
+    def test_get_reference_fields_invalid(self):
+        with self.assertRaises(ValueError) as context:
+            get_reference_fields("nonexistent_type")
+            self.assertIn("Invalid reference type", str(context.exception))
 
+    def test_get_reference_fields_article(self):
+        expected_required = ["author", "title", "journaltitle", "year/date"]
+        expected_optional = [
+            "translator",
+            "annotator",
+            "commentator",
+            "subtitle",
+            "titleaddon",
+            "editor",
+            "editora",
+            "editorb",
+            "editorc",
+            "journalsubtitle",
+            "journaltitleaddon",
+            "issuetitle",
+            "issuesubtitle",
+            "issuetitleaddon",
+            "language",
+            "origlanguage",
+            "series",
+            "volume",
+            "number",
+            "eid",
+            "issue",
+            "month",
+            "pages",
+            "version",
+            "note",
+            "issn",
+            "addendum",
+            "pubstate",
+            "doi",
+            "eprint",
+            "eprintclass",
+            "eprinttype",
+            "url",
+            "urldate",
+        ]
 
-def test_get_reference_fields_invalid():
-    with pytest.raises(ValueError) as excinfo:
-        get_reference_fields("nonexistent_type")
-    assert "Invalid reference type" in str(excinfo.value)
-
-
-def test_get_reference_fields_article():
-    expected_required = ["author", "title", "journaltitle", "year/date"]
-    expected_optional = [
-        "translator",
-        "annotator",
-        "commentator",
-        "subtitle",
-        "titleaddon",
-        "editor",
-        "editora",
-        "editorb",
-        "editorc",
-        "journalsubtitle",
-        "journaltitleaddon",
-        "issuetitle",
-        "issuesubtitle",
-        "issuetitleaddon",
-        "language",
-        "origlanguage",
-        "series",
-        "volume",
-        "number",
-        "eid",
-        "issue",
-        "month",
-        "pages",
-        "version",
-        "note",
-        "issn",
-        "addendum",
-        "pubstate",
-        "doi",
-        "eprint",
-        "eprintclass",
-        "eprinttype",
-        "url",
-        "urldate",
-    ]
-
-    required, optional = get_reference_fields("article")
-    assert required == expected_required
-    assert optional == expected_optional
+        required, optional = get_reference_fields("article")
+        self.assertEqual(required, expected_required)
+        self.assertEqual(optional, expected_optional)


### PR DESCRIPTION
### Description
Converted tests for reference types from pytest to unitest.

### Motivation
This change unifies the project testing methodology.

### Architecture Changes
No changes

### Tests
No new tests. Existing tests are converted.

### Documentation
No changes